### PR TITLE
use cmake 3.5 instead of cmake 3.11

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.5)
 
 get_filename_component(ImGui_SRCDIR "${CMAKE_CURRENT_LIST_DIR}" DIRECTORY)
 

--- a/examples/ImGuiModule.cmake
+++ b/examples/ImGuiModule.cmake
@@ -1,4 +1,7 @@
-include_guard()
+if(__CURRENT_FILE_VAR__)
+  return()
+endif()
+set(__CURRENT_FILE_VAR__ TRUE)
 
 if(EXISTS "${ImGui_SRCDIR}" AND EXISTS "${ImGui_SRCDIR}/imgui.cpp")
     set(ImGui TRUE)

--- a/examples/example_glfw_vulkan/CMakeLists.txt
+++ b/examples/example_glfw_vulkan/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.11)
-
 project(example_glfw_vulkan
     LANGUAGES CXX)
 

--- a/examples/example_null/CMakeLists.txt
+++ b/examples/example_null/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.11)
-
 project(example_null
     LANGUAGES CXX)
 


### PR DESCRIPTION
CMake 3.11 is not used by default on most Non-Windows systems. 